### PR TITLE
fix: Adjust call method order for testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,8 @@ async function run() {
     const taskDefinitionFile = core.getInput('task-definition', { required: true });
     const containerName = core.getInput('container-name', { required: true });
     const imageURI = core.getInput('image', { required: true });
-    const overwrittenEnvList = core.getInput('overwritten-envs');
-
     const environmentVariables = core.getInput('environment-variables', { required: false });
+    const overwrittenEnvList = core.getInput('overwritten-envs');
 
     // Parse the task definition
     const taskDefPath = path.isAbsolute(taskDefinitionFile) ?
@@ -35,7 +34,7 @@ async function run() {
     containerDef.image = imageURI;
 
     // Setup container environment
-    if (overwrittenEnvList != '') {
+    if (overwrittenEnvList) {
       const oriEnvs = containerDef.environment;
       let overwrittenEnvNames = overwrittenEnvList.split(',');
       const newEnvs = [];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Because the tests mock `core.getInput` method to emulate input, but using `mockReturnValueOnce` method that required the call order to be specific order, and we add a custom input field `overwritten-envs` that should be after `environment-variables`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
